### PR TITLE
Refacto budget

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -48,6 +48,7 @@ export interface SiretsFromAPI {
 }
 
 export interface Budget {
+  id: string;
   city: string;
   siren: string;
   siret: string;

--- a/src/routes/budgets/_components/Summary.svelte
+++ b/src/routes/budgets/_components/Summary.svelte
@@ -36,6 +36,7 @@
   import Chart from './Chart.svelte';
 
   export let budgetP: Promise<Budget>;
+
   export let year: number;
   let type: Type = undefined;
   let steps: { label: string; select: () => void }[];
@@ -84,7 +85,7 @@
     return tree;
   }
 
-  $: budgetP.then(async b => {
+  $: budgetP?.then(async b => {
     if (b) {
       const { year, nomen: code } = b;
       budget.set(b);
@@ -126,7 +127,7 @@
     }))
     .sort((a, b) => b.value - a.value);
 
-  $: infosP = budgetP.then(budget => {
+  $: infosP = budgetP?.then(budget => {
     if (budget) {
       const main = type && ($fonction ? $fonction.value[type] : budget[type]);
 

--- a/src/routes/budgets/cache.ts
+++ b/src/routes/budgets/cache.ts
@@ -1,0 +1,89 @@
+import { getRecords } from '@api';
+import { makeBudget, makeId, orderRecordsBySiret } from '@utils';
+import type { Budget, BudgetMap, BudgetRecord } from '@interfaces';
+
+const budgetCache = {} as BudgetMap;
+
+export function fillBudgetBySiret(
+  siret: string,
+  years: number[],
+  name: string,
+): Promise<Budget>[] {
+  const budgets: Promise<Budget>[] = [];
+  years.forEach(currYear => {
+    const id = makeId(siret, currYear);
+
+    const p =
+      id in budgetCache
+        ? Promise.resolve(budgetCache[id])
+        : getRecords({
+            ident: [siret],
+            year: currYear,
+          })
+            .catch(() => [])
+            .then((records: BudgetRecord[]) => {
+              const b = makeBudget({
+                city: name,
+                siret,
+                year: currYear,
+                records,
+              });
+
+              budgetCache[id] = b;
+
+              return b;
+            });
+
+    budgets.push(p);
+  });
+  return budgets;
+}
+
+export function fillBudgetBySirens(
+  sirens: string[],
+  years: number[],
+  name: string,
+): Promise<Budget[]>[] {
+  const sirensToFetch: string[] = [];
+  let siretsInCache: string[] = [];
+
+  sirens.forEach(siren => {
+    const sirets = Object.keys(budgetCache).filter(s => s.startsWith(siren));
+
+    if (sirets.length) {
+      siretsInCache = [...siretsInCache, ...sirets];
+    } else {
+      sirensToFetch.push(siren);
+    }
+  });
+
+  const needToFetch = sirensToFetch.length > 0;
+
+  return [...years].reverse().map(year => {
+    const cached = siretsInCache.map(id => budgetCache[id]).filter(b => b);
+
+    return !needToFetch
+      ? Promise.resolve(cached)
+      : Promise.all([
+          Promise.resolve(cached),
+          getRecords({ siren: sirensToFetch, year })
+            .catch(() => [])
+            .then((records: BudgetRecord[]) =>
+              orderRecordsBySiret(records).map(({ siret, records }) => {
+                const b = makeBudget({
+                  city: name,
+                  siret,
+                  year,
+                  records,
+                });
+                const id = makeId(siret, year);
+                if (!(id in budgetCache)) {
+                  budgetCache[id] = b;
+                }
+
+                return b;
+              }),
+            ),
+        ]).then(budgets => budgets.flat());
+  });
+}

--- a/src/routes/budgets/index.svelte
+++ b/src/routes/budgets/index.svelte
@@ -81,15 +81,6 @@
 
   let budgetById: BudgetMap = {};
 
-  // TODO: remove after check
-  $: if (name !== $city?.nom)
-    $city = {
-      nom: name,
-      code: insee,
-      departement: { code: '12', nom: 'Jean' },
-      region: { code: '12', nom: 'Jean' },
-      population: 2000,
-    };
   $: if ($city) budgetById = {};
 
   function selectSiret(s: string): void {
@@ -195,9 +186,6 @@
       {#if label}
         <h2>{label}</h2>
       {/if}
-
-      <!-- TODO: remove after check -->
-      <a href="/budgets?name=Annecy&insee=74010">Annecy</a>
     </div>
 
     <div class="departement">

--- a/src/utils/budget.ts
+++ b/src/utils/budget.ts
@@ -1,4 +1,5 @@
 import json2csv from 'json-2-csv';
+import { makeId } from '@utils';
 
 import type {
   CSV,
@@ -75,6 +76,8 @@ export async function makeCSV(data: Budget): Promise<CSV> {
 export function makeBudget(data: BudgetRaw): Budget {
   const { city, siret, year, records } = data;
 
+  const id = makeId(siret, year);
+
   const length = records.length;
 
   if (length === 0) return null;
@@ -102,6 +105,7 @@ export function makeBudget(data: BudgetRaw): Budget {
   const nomen = nomens.length > 0 ? nomens[0] : '';
 
   return {
+    id,
     siret,
     siren,
     etabl,


### PR DESCRIPTION
- [x] switch back to `sirens`-based urls
- [x] write `fillBudgetBySirens` (use `.map` instead of `.forEach`) and `fillBudgetBySiret`
- [x] in `context="module"`, redirect to url with siret and sirens if `(!siret || !sirens)` (see Svelte-Kit doc)
- [x] cache budgets in `budgetCache` (never reset) and `budgetById` (reset when `$city` changes)

## Caching tips

### fillBudgetBySirens
Retrieving cache from `budgetCache` for `fillBudgetBySirens` can be tricky.
For each siren:
- get all sirets from cache
- filter those which start with siren
- if the filtered sirets array is not empty, return the array of all these keys, and remove siren from the local sirens array
- if not, fetch normally with `getRecords`
